### PR TITLE
Fixed switching to light_temperature changing to a wrong initial value

### DIFF
--- a/lib/zigbee/ZigBeeXYLightDevice.js
+++ b/lib/zigbee/ZigBeeXYLightDevice.js
@@ -107,7 +107,7 @@ class ZigBeeXYLightDevice extends ZigBeeDevice {
 						}
 
 						// Set light temperature
-						const temperature = 0.2 + value / 4;
+						const temperature = 0.2 + this.getCapabilityValue('light_temperature') / 4;
 						return {
 							colorx: temperature * CIEMultiplier,
 							colory: temperature * CIEMultiplier,


### PR DESCRIPTION
`value === 'temperature'` which would cause the light temperature to not be set correctly when no "light_temperature" was is given (e.g. when switching modes)