### PR TITLE
add dim/BASIC, change onoff/BASIC & onoff/SWITCH_BINARY

### DIFF
--- a/lib/zwave/system/capabilities/dim/BASIC.js
+++ b/lib/zwave/system/capabilities/dim/BASIC.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+	get: 'BASIC_GET',
+	set: 'BASIC_SET',
+	setParser(value) {
+		if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', value > 0);
+		return {
+			Value: Math.round(value * 99),
+		};
+	}),
+	report: 'BASIC_REPORT',
+	reportParser: report => {
+		if (report && report.hasOwnProperty('Value')) {
+			if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', value > 0);
+			if (report['Value'] > 99) return 1;
+			return report['Value'] / 99;
+		}
+		return null;
+	}
+};

--- a/lib/zwave/system/capabilities/onoff/BASIC.js
+++ b/lib/zwave/system/capabilities/onoff/BASIC.js
@@ -8,7 +8,7 @@ module.exports = {
 	}),
 	report: 'BASIC_REPORT',
 	reportParser(report) {
-		if (report && report.hasOwnProperty('Value')) return report.Value === 255;
+		if (report && report.hasOwnProperty('Value')) return report.Value > 0;
 		return null;
 	},
 };

--- a/lib/zwave/system/capabilities/onoff/SWITCH_BINARY.js
+++ b/lib/zwave/system/capabilities/onoff/SWITCH_BINARY.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const util = require('./../../../../util');
-
 const FACTORY_DEFAULT_DIMMING_DURATION = 'Default';
 
 module.exports = {
@@ -13,15 +12,22 @@ module.exports = {
 	setParserV2(value, options) {
 		const duration = (options.hasOwnProperty('duration') ? util.calculateZwaveDimDuration(options.duration) : FACTORY_DEFAULT_DIMMING_DURATION);
 		return {
-			'Switch Value': (value) ? 'on/enable' : 'off/disable',
-			'Dimming Duration': duration,
+			'Target Value': (value) ? 'on/enable' : 'off/disable',
+			'Duration': duration,
 		};
 	},
 	report: 'SWITCH_BINARY_REPORT',
-	reportParser: report => {
+	reportParserV1: report => {
 		if (report && report.hasOwnProperty('Value')) {
 			if (report.Value === 'on/enable') return true;
 			else if (report.Value === 'off/disable') return false;
+		}
+		return null;
+	},
+	reportParserV2: report => {
+		if (report && report.hasOwnProperty('Current Value')) {
+			if (report['Current Value'] === 'on/enable') return true;
+			else if (report['Current Value'] === 'off/disable') return false;
 		}
 		return null;
 	},


### PR DESCRIPTION
added the BASIC command class for the dim capability,
as BASIC can be used for dimming purposes (0 - 99)

changed the method for BASIC command class for the onoff capability,
as the value can be anything
from 1 till 99
and 255
to determine if it is "on"

added "reportParser" for v2 of the SWITCH_BINARY in onoff capability,
as it was missing, it would not update the capability if a device has v2
(different value name)

also fixed the "setParser" of v2 as it was copy pasted from SWITCH_MULTILEVEL
but the values are actually different.
even though it would fall back to v1 to still trigger the device, it could never have used the Duration property
these changes are made based on the SDKv1 Neo app, and the large XML file used by homey at the start of the rewrite, which already included v2 of Binary Switch