### PR TITLE
change onoff/BASIC & onoff/SWITCH_BINARY

### DIFF
--- a/lib/zwave/system/capabilities/onoff/BASIC.js
+++ b/lib/zwave/system/capabilities/onoff/BASIC.js
@@ -8,7 +8,7 @@ module.exports = {
 	}),
 	report: 'BASIC_REPORT',
 	reportParser(report) {
-		if (report && report.hasOwnProperty('Value')) return report.Value === 255;
+		if (report && report.hasOwnProperty('Value')) return report.Value > 0;
 		return null;
 	},
 };

--- a/lib/zwave/system/capabilities/onoff/SWITCH_BINARY.js
+++ b/lib/zwave/system/capabilities/onoff/SWITCH_BINARY.js
@@ -13,15 +13,22 @@ module.exports = {
 	setParserV2(value, options) {
 		const duration = (options.hasOwnProperty('duration') ? util.calculateZwaveDimDuration(options.duration) : FACTORY_DEFAULT_DIMMING_DURATION);
 		return {
-			'Switch Value': (value) ? 'on/enable' : 'off/disable',
-			'Dimming Duration': duration,
+			'Target Value': (value) ? 'on/enable' : 'off/disable',
+			'Duration': duration,
 		};
 	},
 	report: 'SWITCH_BINARY_REPORT',
-	reportParser: report => {
+	reportParserV1: report => {
 		if (report && report.hasOwnProperty('Value')) {
 			if (report.Value === 'on/enable') return true;
 			else if (report.Value === 'off/disable') return false;
+		}
+		return null;
+	},
+	reportParserV2: report => {
+		if (report && report.hasOwnProperty('Current Value')) {
+			if (report['Current Value'] === 'on/enable') return true;
+			else if (report['Current Value'] === 'off/disable') return false;
 		}
 		return null;
 	},


### PR DESCRIPTION
changed the method for BASIC command class for the onoff capability, as
the value van be anything
from 1 till 99
and 255
for to determing if it is "on"

added "reportParser" for v2 of the SWITCH_BINARY in onoff capability, as
it was missing,
it will not update the capability if a device has v2
(different value name)

also fixed the "setParser" of v2 as it was copy pasted from
SWITCH_MULTILEVEL but the values are actually different.
even though it would fall back to v1 to still trigger the device,
it could never have used the Duration property