### PR TITLE
fix when using signed values in settings

### DIFF
--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -145,6 +145,7 @@ class ZwaveDevice extends MeshDevice {
 					id: changedKey,
 					index: manifestSetting.index,
 					size: manifestSetting.size,
+					signed: (manifestSetting.hasOwnProperty('signed') ? manifestSetting.signed : undefined),
 				}, newSettings[changedKey]);
 			} catch (err) {
 				this.error(`failed_to_set_${changedKey}_to_${newValue}_size_${manifestSetting.size}`, err);


### PR DESCRIPTION
when using this setting in a device.json configuration, this exception is thrown when sending value 255:
"failed_to_set_config_param_4_to_255_size_1 TypeError: "value" argument is out of bounds":

`
        {
            "id": "config_param_4",
            "type": "dropdown",
            "label": {
                "en": "All on/off",
                "nl": "Volledig aan/uit"
            },
            "value": "255",
            "values": [
                {
                    "id": "0",
                    "label": {
                        "en": "Forbit all on and forbit all off",
                        "nl": "Voorkom volledig aan en voorkom volledig uit"
                    }
                },
                {
                    "id": "1",
                    "label": {
                        "en": "Forbit all on and allow all off",
                        "nl": "Voorkom volledig aan en volledig uit toestaan"
                    }
                },
                {
                    "id": "2",
                    "label": {
                        "en": "Allow all on and forbit all off",
                        "nl": "Volledig aan toestaan en voorkom volledig uit"
                    }
                },
                {
                    "id": "255",
                    "label": {
                        "en": "Allow all on and allow all off",
                        "nl": "Volledig aan toestaan en volledig uit toestaan"
                    }
                }
            ],
            "zwave": {
                "index": 4,
                "size": 1,
                "signed": false
            }
        },
`

This is caused by the fact that the signed property is not added to the options when calling the method configurationSet(). So the value is handled as a signed int and the max positive value is 127.
