### PR TITLE
[Z-Wave] update settings functions

### DIFF
--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -136,11 +136,19 @@ class ZwaveDevice extends MeshDevice {
 			// Get manifest setting object and execute configuration set
 			const manifestSetting = (this.getManifestSettings().find(setting => setting.id === changedKey) || {}).zwave;
 
-			// Do not try to handle non-zwave settings
-			if (typeof manifestSetting === 'undefined') continue;
+			// Non z-wave settings: see if there is a function to execute, otherwise do nothing.
+			if (typeof manifestSetting === 'undefined') {
+
+				if (this._settings.hasOwnProperty(changedKey)) {
+					const parser = this._settings[changedKey];
+
+					if (typeof parser === 'function') parser.call(this, newValue);
+				}
+				continue;
+			}
 
 			try {
-				this.log(`configurationSet() -> ${changedKey}:${newSettings[changedKey]}, ${manifestSetting.index}, ${manifestSetting.size}`);
+				this.log(`configurationSet() -> ${changedKey}: ${newSettings[changedKey]}, ${manifestSetting.index}, ${manifestSetting.size}`);
 				await this.configurationSet({
 					id: changedKey,
 					index: manifestSetting.index,
@@ -221,7 +229,7 @@ class ZwaveDevice extends MeshDevice {
 			}
 			options.index = settingObj.zwave.index;
 			options.size = settingObj.zwave.size;
-			options.signed = (settingObj.zwave.hasOwnProperty('signed')) ? settingObj.zwave.signed : true;
+			options.signed = (!options.hasOwnProperty('signed') && settingObj.zwave.hasOwnProperty('signed')) ? settingObj.zwave.signed : true;
 		}
 
 		// Check if device has command class

--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -145,6 +145,7 @@ class ZwaveDevice extends MeshDevice {
 					id: changedKey,
 					index: manifestSetting.index,
 					size: manifestSetting.size,
+					signed: (manifestSetting.hasOwnProperty('signed')) ? manifestSetting.signed : true
 				}, newSettings[changedKey]);
 			} catch (err) {
 				this.error(`failed_to_set_${changedKey}_to_${newValue}_size_${manifestSetting.size}`, err);
@@ -199,6 +200,7 @@ class ZwaveDevice extends MeshDevice {
 	 * @param options.index
 	 * @param options.size
 	 * @param options.id
+	 * @param [options.signed]
 	 * @param [options.useSettingParser=true]
 	 * @param value
 	 * @returns {Promise.<*>}
@@ -206,7 +208,7 @@ class ZwaveDevice extends MeshDevice {
 	async configurationSet(options = {}, value) {
 		if (!options.hasOwnProperty('index') && !options.hasOwnProperty('id')) return Promise.reject(new Error('missing_setting_index_or_id'));
 		if (options.hasOwnProperty('index') && !options.hasOwnProperty('size')) return Promise.reject(new Error('missing_setting_size'));
-		if (options.hasOwnProperty('id') && !options.hasOwnProperty('size') && !options.hasOwnProperty('index')) {
+		if (options.hasOwnProperty('id') && (!options.hasOwnProperty('size') || !options.hasOwnProperty('index') || !options.hasOwnProperty('signed'))) {
 
 			// Fetch information from manifest by setting id
 			const settingObj = this.getManifestSetting(options.id);
@@ -219,7 +221,7 @@ class ZwaveDevice extends MeshDevice {
 			}
 			options.index = settingObj.zwave.index;
 			options.size = settingObj.zwave.size;
-			if (settingObj.zwave.hasOwnProperty('signed')) options.signed = settingObj.zwave.signed;
+			options.signed = (settingObj.zwave.hasOwnProperty('signed')) ? settingObj.zwave.signed : true;
 		}
 
 		// Check if device has command class
@@ -248,11 +250,17 @@ class ZwaveDevice extends MeshDevice {
 				},
 				'Configuration Value': parsedValue || value,
 			}, (err, result) => {
+				const parsedBufValue = parsedValue.toString('hex').toUpperCase();
+
+				let parsedDecValue;
+				if (!options.hasOwnProperty('signed') || options.signed === true) parsedDecValue = parsedValue.readIntBE(0, options.size);
+				else parsedDecValue = parsedValue.readUIntBE(0, options.size);
+
 				if (err) {
-					this.error(`configurationSet() -> failed to set configuration parameter ${options.index}, size: ${options.size} to ${value} (parsed: ${parsedValue})`);
+					this.error(`configurationSet() -> failed to set configuration parameter ${options.index}, size: ${options.size} to ${value} (parsed: ${parsedDecValue} /  0x${parsedBufValue})`);
 					return reject(err);
 				}
-				this.log(`configurationSet() -> successful set ${options.index}, size: ${options.size} to ${value} (parsed: ${parsedValue})`);
+				this.log(`configurationSet() -> successfully set ${options.index}, size: ${options.size} to ${value} (parsed: ${parsedDecValue} / 0x${parsedBufValue})`);
 				return resolve(result);
 			});
 
@@ -283,9 +291,9 @@ class ZwaveDevice extends MeshDevice {
 		if (typeof parser !== 'function') return new Error('invalid_parser');
 
 		// Parse and check value
-		const parsedValue = parser.call(this, value, settingObj);
+		let parsedValue = parser.call(this, value, settingObj);
 		if (parsedValue instanceof Error) return parsedValue;
-		if (!Buffer.isBuffer(parsedValue)) return new Error('invalid_buffer');
+		if (!Buffer.isBuffer(parsedValue)) parsedValue = this._systemSettingParser(parsedValue, settingObj);
 		if (parsedValue.length !== settingObj.size) return new Error('invalid_buffer_length');
 		return parsedValue;
 	}
@@ -651,7 +659,7 @@ class ZwaveDevice extends MeshDevice {
 	/**
 	 * Register a setting parser, which is called when a setting has changed.
 	 * @param {string} settingId - The setting ID, as specified in `/app.json`
-	 * @param {Function} parserFn - The parser function, must return a Buffer
+	 * @param {Function} parserFn - The parser function, must return a Buffer, number or boolean
 	 * @param {Mixed} parserFn.value - The setting value
 	 * @param {Mixed} parserFn.zwaveObj - The setting's `zwave` object as defined in `/app.json`
 	 */

--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -229,7 +229,7 @@ class ZwaveDevice extends MeshDevice {
 			}
 			options.index = settingObj.zwave.index;
 			options.size = settingObj.zwave.size;
-			options.signed = (!options.hasOwnProperty('signed') && settingObj.zwave.hasOwnProperty('signed')) ? settingObj.zwave.signed : true;
+			if (!options.hasOwnProperty('signed')) options.signed = (settingObj.zwave.hasOwnProperty('signed')) ? settingObj.zwave.signed : true;
 		}
 
 		// Check if device has command class

--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -229,7 +229,10 @@ class ZwaveDevice extends MeshDevice {
 			}
 			options.index = settingObj.zwave.index;
 			options.size = settingObj.zwave.size;
-			if (!options.hasOwnProperty('signed')) options.signed = (settingObj.zwave.hasOwnProperty('signed')) ? settingObj.zwave.signed : true;
+
+			if (!options.hasOwnProperty('signed')) {
+				options.signed = (settingObj.zwave.hasOwnProperty('signed')) ? settingObj.zwave.signed : true;
+			}
 		}
 
 		// Check if device has command class
@@ -259,10 +262,15 @@ class ZwaveDevice extends MeshDevice {
 				'Configuration Value': parsedValue || value,
 			}, (err, result) => {
 				const parsedBufValue = parsedValue.toString('hex').toUpperCase();
-
 				let parsedDecValue;
-				if (!options.hasOwnProperty('signed') || options.signed === true) parsedDecValue = parsedValue.readIntBE(0, options.size);
-				else parsedDecValue = parsedValue.readUIntBE(0, options.size);
+				
+				try {
+					if (!options.hasOwnProperty('signed') || options.signed === true) parsedDecValue = parsedValue.readIntBE(0, options.size);
+					else parsedDecValue = parsedValue.readUIntBE(0, options.size);
+				} catch(error) {
+					this.error(`failed to read the buffer value`, error);
+					parsedDecValue = 'N/A';
+				}
 
 				if (err) {
 					this.error(`configurationSet() -> failed to set configuration parameter ${options.index}, size: ${options.size} to ${value} (parsed: ${parsedDecValue} /  0x${parsedBufValue})`);
@@ -293,15 +301,34 @@ class ZwaveDevice extends MeshDevice {
 	 * @private
 	 */
 	_parseSetting(settingObj = {}, value) {
+		let parser, customParser
 
 		// get the parser
-		const parser = this._settings[settingObj.id] || this._systemSettingParser;
+		if (typeof this._settings[settingObj.id] !== 'undefined') {
+			parser = this._settings[settingObj.id];
+			customParser = true;
+		} else {
+			parser = this._systemSettingParser;
+		}
+
 		if (typeof parser !== 'function') return new Error('invalid_parser');
 
 		// Parse and check value
 		let parsedValue = parser.call(this, value, settingObj);
 		if (parsedValue instanceof Error) return parsedValue;
-		if (!Buffer.isBuffer(parsedValue)) parsedValue = this._systemSettingParser(parsedValue, settingObj);
+		if (!Buffer.isBuffer(parsedValue)) {
+
+			if (customParser) {
+				parsedValue = this._systemSettingParser(parsedValue, settingObj);
+
+				if (!Buffer.isBuffer(parsedValue)) {
+					return new Error('invalid_buffer');
+				}
+			} else {
+				return new Error('invalid_buffer');
+			}
+		}
+
 		if (parsedValue.length !== settingObj.size) return new Error('invalid_buffer_length');
 		return parsedValue;
 	}


### PR DESCRIPTION
r139-151:
this will check if there is a parser/function available for a non z-wave setting to execute,
making it way easier to add non parameter settings, then to override the onSettings function

r148/156:
to fetch the current signed value if it is there and send it allong, same as #50 though added another check in the configurationSet() function otherwise the signed is not used when using the configurationSet directly, still left it in to save another getManifestSettings trigger being initiated in the configurationSet function

r203/211:
add the optional option.signed

r211/219:
make sure all 3 (index, size AND signed) values are present in configurationSet(), if not
fetch latest from the manifest, the signed tag wasn't looked at all if the value wasn't send allong making a lot of settings be determined out of bounds.
practically this fixes what r148/#50 is also doing, but then more broad.

r253/232-263/271:
the debug log wasn't very descriptive when using a parser, also the
parsed value wasn't displayed properly.
`successfully set 23, size: 2 to 64 (parsed: �)`
now the log is displaying both parsed decimal and parsed buffer values
`configurationSet() -> successfully set 23, size: 2 to 64 (parsed: 64000 / 0xFA00)`

r294/304-296/306, r662/670:
now the returning value needs to be a buffer value if not it will throw an error.
with this if the returning parser value is not a buffer, it will just send it on to the
systemSettingParser to convert it, saving the trouble of having to do it
in the driver (noob/error proofing, and saving 2 lines of code when size is not 1 per setting)
mesh driver is there to make is easy, forcing a buffer value makes it more difficult then it needs to be.

\* line number commit  1 / line number after commit 2