### PR TITLE
[Z-Wave] catch central scene echo's

### DIFF
--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -670,11 +670,35 @@ class ZwaveDevice extends MeshDevice {
 		const commandClass = this.node.CommandClass[`COMMAND_CLASS_${commandClassId}`];
 		if (typeof commandClass === 'undefined') return this.error('Invalid commandClass:', commandClassId);
 
+		if commandId === 'CENTRAL_SCENE_NOTIFICATION') let previousSequence;
+
 		this._reportListeners[commandClassId] = this._reportListeners[commandClassId] || {};
 		this._reportListeners[commandClassId][commandId] = triggerFn;
 
 		commandClass.on('report', (command, payload) => {
 			if (command.name !== commandId) return;
+
+ 			// Catch central scene echos and (sometimes) failing parser
+ 			if (command.name === 'CENTRAL_SCENE_NOTIFICATION') {
+
+ 				if (typeof previousSequence !== 'undefined' && payload.hasOwnProperty('Sequence Number') && payload['Sequence Number'] === previousSequence) return;
+ 				previousSequence = payload['Sequence Number'];
+
+ 				if (payload.hasOwnProperty('Properties1') &&
+ 					payload.Properties1.hasOwnProperty('Key Attributes') &&
+ 					typeof payload.Properties1['Key Attributes'] === 'number') {
+ 					switch(payload.Properties1['Key Attributes']) {
+ 						case 0: payload.Properties1['Key Attributes'] = 'Key Pressed 1 time'; break;
+ 						case 1: payload.Properties1['Key Attributes'] = 'Key Released'; break;
+ 						case 2: payload.Properties1['Key Attributes'] = 'Key Held Down'; break;
+ 						case 3: payload.Properties1['Key Attributes'] = 'Key Pressed 2 times'; break;
+ 						case 4: payload.Properties1['Key Attributes'] = 'Key Pressed 3 times'; break;
+ 						case 5: payload.Properties1['Key Attributes'] = 'Key Pressed 4 times'; break;
+ 						case 6: payload.Properties1['Key Attributes'] = 'Key Pressed 5 times'; break;
+ 					}
+ 				}
+ 			}
+
 			if (this._reportListeners[commandClassId] &&
 				this._reportListeners[commandClassId][command.name]) {
 				this._reportListeners[commandClassId][command.name](payload);

--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -669,8 +669,7 @@ class ZwaveDevice extends MeshDevice {
 	registerReportListener(commandClassId, commandId, triggerFn) {
 		const commandClass = this.node.CommandClass[`COMMAND_CLASS_${commandClassId}`];
 		if (typeof commandClass === 'undefined') return this.error('Invalid commandClass:', commandClassId);
-
-		if commandId === 'CENTRAL_SCENE_NOTIFICATION') let previousSequence;
+		let previousSequence;
 
 		this._reportListeners[commandClassId] = this._reportListeners[commandClassId] || {};
 		this._reportListeners[commandClassId][commandId] = triggerFn;


### PR DESCRIPTION
this addition will catch echo's (unwanted multiple commands) as result of the z-wave
broadcast mechanism on the central scene command class
```
2018-01-14 20:33:20 [log] [ManagerDrivers] [ZRC-90] [1] **Pre catch**: Sequence: 83, Previous Sequence: 82
2018-01-14 20:33:20 [log] [ManagerDrivers] [ZRC-90] [1] **After catch**: Sequence: 83, Previous Sequence: 82
2018-01-14 20:33:20 [log] [ManagerDrivers] [ZRC-90] [1] **Pre catch**: Sequence: 83, Previous Sequence: 83
2018-01-14 20:33:20 [log] [ManagerDrivers] [ZRC-90] [1] **Pre catch**: Sequence: 83, Previous Sequence: 83
2018-01-14 20:33:21 [log] [ManagerDrivers] [ZRC-90] [1] **Pre catch**: Sequence: 83, Previous Sequence: 83
2018-01-14 20:33:22 [log] [ManagerDrivers] [ZRC-90] [1] **Pre catch**: Sequence: 84, Previous Sequence: 83
```

also there is a chance the device's central scene "key attributes" are not parsed in the core.
Resulting in a value of "0 - 6" instead of "Key Pressed 1 time, Key Released, Key Held Down, Key Pressed # times"
```
2018-01-13 13:32:11 [log] [ManagerDrivers] [ZRC-90] [1] { payload.Properties1['Key Attributes']: 0 }
2018-01-13 13:33:51 [log] [ManagerDrivers] [ZRC-90] [0] { payload.Properties1['Key Attributes']: 'Key Pressed 1 time' }
```
[0] = older device
[1] = newer device (v1.5.6 RC8)
same manufacturer/id's/command class versions, so not sure why this happens(?), the "newer device" is included on a later homey fw version, not sure anymore what version we were in for the "older device"