### PR TITLE
[Z-Wave] add option to have capability as optional

### DIFF
--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -591,12 +591,17 @@ class ZwaveDevice extends MeshDevice {
 	 * @param {Function} [opts.reportParser] - The function that is called when a REPORT request is made. Should return an Object.
 	 * @param {Object} [opts.reportParser.report] - The report object
 	 * @param {Number} [opts.multiChannelNodeId] - An ID to use a MultiChannel Node for this capability
+	 * @param {Boolean} [opts.optional] - If the capability might be optional
 	 */
 	registerCapability(capabilityId, commandClassId, userOpts) {
 
-		// Check if device has the command class we're trying to register, if not, abort
+		// Check if device has the command class we're trying to register, if not check if optional, otherwise abort
 		if (typeof this.node.CommandClass[`COMMAND_CLASS_${commandClassId}`] === 'undefined') {
-			return this.error('Invalid commandClass:', commandClassId);
+
+			if (!userOpts.hasOwnProperty('optional') || userOpts.optional === false) {
+				return this.error('Invalid commandClass:', commandClassId);
+			}
+			return null;
 		}
 
 		// register the Z-Wave capability listener


### PR DESCRIPTION
as some devices have an _optional_ capability
IE: (older) fibaro door sensor (FGK-10X) with a temperature sensor that you can attach separately.

with this you can add a `optional: true` tag so it will not give any errors.

i know it will just give an error message in the logs, so if you don't find this necessary you can close it.
just showing another state of mind.

would be best to catch this _during_ pairing anyway, so the capability is not show at all, but that is not something i can add/change.