### PR TITLE
[Z-Wave] add pollIntervalMultiplier

### DIFF
--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -365,13 +365,14 @@ class ZwaveDevice extends MeshDevice {
 		if (capabilityGetObj.opts.pollInterval) {
 
 			let pollInterval;
+			const pollIntervalMultiplier = capabilityGetObj.opts.pollIntervalMultiplier || 1;
 
 			if (typeof capabilityGetObj.opts.pollInterval === 'number') {
-				pollInterval = capabilityGetObj.opts.pollInterval;
+				pollInterval = capabilityGetObj.opts.pollInterval * pollIntervalMultiplier;
 			}
 
 			if (typeof capabilityGetObj.opts.pollInterval === 'string') {
-				pollInterval = this.getSetting(capabilityGetObj.opts.pollInterval);
+				pollInterval = this.getSetting(capabilityGetObj.opts.pollInterval) * pollIntervalMultiplier;
 				this._pollIntervalsKeys[capabilityGetObj.opts.pollInterval] = {
 					capabilityId,
 					commandClassId,
@@ -583,6 +584,7 @@ class ZwaveDevice extends MeshDevice {
 	 * @param {Boolean} [opts.getOpts.getOnStart] - Get the value on App start
 	 * @param {Boolean} [opts.getOpts.getOnOnline] - Get the value when the device is marked as online
 	 * @param {Number|String} [opts.getOpts.pollInterval] - Interval (in ms) to poll with a GET request. When provided a string, the device's setting with the string as ID will be used (e.g. `poll_interval`)
+	 * @param {Number} [opts.getOpts.pollIntervalMultiplier] - To multiply the poll interval value (e.g. for seconds: 1000)
 	 * @param {String} [opts.set] - The command to set a value (e.g. `BASIC_SET`)
 	 * @param {Function} [opts.setParser] - The function that is called when a SET request is made. Should return an Object.
 	 * @param {Mixed} [opts.setParser.value] - The value of the Homey capability


### PR DESCRIPTION
with no multiplication by default (ms) it will break a lot of current SDKv1 apps going to be converted to SDKv2 using a setting for pollInterval value(s) (as these are most (if not all) specified in seconds, not milliseconds, to keep it user friendly)

but also 300000 (5 minutes) as a setting value is not really user friendly

so this will add a pollIntervalMultiplier option to convert the value.
Can't add the *1000 multiplication standard, as that breaks current SDKv2 apps (e.g. Samsung Z-Wave Locks)
and this also gives the developer more possibilities, might he/she want to have a minutes/hours conversion