### PR TITLE
fixed using wrong clusterId in _registerCapabilitiesSet

### DIFF
--- a/lib/zigbee/ZigBeeDevice.js
+++ b/lib/zigbee/ZigBeeDevice.js
@@ -193,7 +193,7 @@ class ZigBeeDevice extends MeshDevice {
 
 				// Loop all changed capabilities
 				for (const capabilityId of Object.keys(valueObj)) {
-					const capabilityObj = capabilitiesOpts.find(x => x.capability = capabilityId);
+					const capabilityObj = capabilitiesOpts.find(x => x.capability === capabilityId);
 					const clusterId = capabilityObj.cluster;
 					const value = valueObj[capabilityId];
 					const opts = optsObj[capabilityId];


### PR DESCRIPTION
capabilityObj is always the first item in capabilitiesOpts because "x.capability = capabilityId" always returns true. so when you use multiple different clusterIds in the capabilitiesOpts, it is possible that the found clusterId is not the clusterId for the given capabilityId.