### PR TITLE
Prevent registerCapability overwriting systemOpts

### DIFF
--- a/lib/zigbee/ZigBeeDevice.js
+++ b/lib/zigbee/ZigBeeDevice.js
@@ -279,6 +279,7 @@ class ZigBeeDevice extends MeshDevice {
 		else if (typeof userOpts === 'undefined') userOpts = { endpoint: this.getClusterEndpoint(clusterId) };
 
 		this._capabilities[capabilityId][clusterId] = Object.assign(
+			{},
 			systemOpts || {},
 			userOpts || {}
 		);

--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -721,6 +721,7 @@ class ZwaveDevice extends MeshDevice {
 		}
 
 		this._capabilities[capabilityId][commandClassId] = Object.assign(
+			{},
 			systemOpts || {},
 			userOpts || {}
 		);


### PR DESCRIPTION
`userOpts` passed to `registerCapability` calls were overwriting `systemOpts` for a particular capability/command class or capability/cluster id combination.
This could lead to unpredictable behavior if multiple drivers defined by the same app are in use.

For example:
Suppose two different device types with two different drivers from the same brand are in use. Both devices support the same capability/command class combination. One of the drivers provides `userOpts`, but the other doesn't. The one using the default settings may end up using the `userOpts` from the other driver, if that driver is initialized last.

(`object.assign` modifies the first object passed to it)