### PR TITLE
Z-Wave: improve meter parsers

### DIFF
--- a/lib/zwave/system/capabilities/measure_current/METER.js
+++ b/lib/zwave/system/capabilities/measure_current/METER.js
@@ -69,8 +69,9 @@ module.exports = {
 			report.hasOwnProperty('Properties2') &&
 			report.Properties2.hasOwnProperty('Scale bits 10') &&
 			report.Properties2['Scale bits 10'] === 1 &&
-			report.hasOwnProperty('Scale 2') &&
-			report['Scale 2'] === 0) {
+			report.hasOwnProperty('Scale 2') === false ||
+			report.hasOwnProperty('Scale 2')
+			&& report['Scale 2'] === 0) {
 			return report['Meter Value (Parsed)'];
 		}
 		return null;

--- a/lib/zwave/system/capabilities/measure_power/METER.js
+++ b/lib/zwave/system/capabilities/measure_power/METER.js
@@ -92,8 +92,9 @@ module.exports = {
 			report.hasOwnProperty('Properties2') &&
 			report.Properties2.hasOwnProperty('Scale bits 10') &&
 			report.Properties2['Scale bits 10'] === 2 &&
-			report.hasOwnProperty('Scale 2') &&
-			report['Scale 2'] === 0) {
+			report.hasOwnProperty('Scale 2') === false ||
+			report.hasOwnProperty('Scale 2')
+			&& report['Scale 2'] === 0) {
 			return report['Meter Value (Parsed)'];
 		}
 		return null;

--- a/lib/zwave/system/capabilities/measure_voltage/METER.js
+++ b/lib/zwave/system/capabilities/measure_voltage/METER.js
@@ -68,8 +68,9 @@ module.exports = {
 			report.hasOwnProperty('Properties2') &&
 			report.Properties2.hasOwnProperty('Scale bits 10') &&
 			report.Properties2['Scale bits 10'] === 0 &&
-			report.hasOwnProperty('Scale 2') &&
-			report['Scale 2'] === 0) {
+			report.hasOwnProperty('Scale 2') === false ||
+			report.hasOwnProperty('Scale 2')
+			&& report['Scale 2'] === 0) {
 			return report['Meter Value (Parsed)'];
 		}
 		return null;

--- a/lib/zwave/system/capabilities/meter_power/METER.js
+++ b/lib/zwave/system/capabilities/meter_power/METER.js
@@ -91,8 +91,9 @@ module.exports = {
 			report.hasOwnProperty('Properties2') &&
 			report.Properties2.hasOwnProperty('Scale bits 10') &&
 			report.Properties2['Scale bits 10'] === 0 &&
-			report.hasOwnProperty('Scale 2') &&
-			report['Scale 2'] === 0) {
+			report.hasOwnProperty('Scale 2') === false ||
+			report.hasOwnProperty('Scale 2')
+			&& report['Scale 2'] === 0) {
 			return report['Meter Value (Parsed)'];
 		}
 		return null;

--- a/lib/zwave/system/capabilities/powerFactor/METER.js
+++ b/lib/zwave/system/capabilities/powerFactor/METER.js
@@ -68,8 +68,9 @@ module.exports = {
 			report.hasOwnProperty('Properties2') &&
 			report.Properties2.hasOwnProperty('Scale bits 10') &&
 			report.Properties2['Scale bits 10'] === 2 &&
-			report.hasOwnProperty('Scale 2') &&
-			report['Scale 2'] === 0) {
+			report.hasOwnProperty('Scale 2') === false ||
+			report.hasOwnProperty('Scale 2')
+			&& report['Scale 2'] === 0) {
 			return report['Meter Value (Parsed)'];
 		}
 		return null;

--- a/lib/zwave/system/capabilities/powerReactive/METER.js
+++ b/lib/zwave/system/capabilities/powerReactive/METER.js
@@ -69,8 +69,9 @@ module.exports = {
 			report.hasOwnProperty('Properties2') &&
 			report.Properties2.hasOwnProperty('Scale bits 10') &&
 			report.Properties2['Scale bits 10'] === 3 &&
-			report.hasOwnProperty('Scale 2') &&
-			report['Scale 2'] === 0) {
+			report.hasOwnProperty('Scale 2') === false ||
+			report.hasOwnProperty('Scale 2')
+			&& report['Scale 2'] === 0) {
 			return report['Meter Value (Parsed)'];
 		}
 		return null;

--- a/lib/zwave/system/capabilities/powerTotalApparent/METER.js
+++ b/lib/zwave/system/capabilities/powerTotalApparent/METER.js
@@ -68,8 +68,9 @@ module.exports = {
 			report.hasOwnProperty('Properties2') &&
 			report.Properties2.hasOwnProperty('Scale bits 10') &&
 			report.Properties2['Scale bits 10'] === 1 &&
-			report.hasOwnProperty('Scale 2') &&
-			report['Scale 2'] === 0) {
+			report.hasOwnProperty('Scale 2') === false ||
+			report.hasOwnProperty('Scale 2')
+			&& report['Scale 2'] === 0) {
 			return report['Meter Value (Parsed)'];
 		}
 		return null;


### PR DESCRIPTION
Z-Wave only check for Scale 2 prop if present, seems that some devices do not send that parameter (when it is zero assumably).