### PR TITLE
pollMultiplication not working onSettings update

### DIFF
--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -146,10 +146,15 @@ class ZwaveDevice extends MeshDevice {
 
 			// check for poll interval
 			if (this._pollIntervalsKeys[changedKey]) {
+				const capabilityGetObj = this._getCapabilityObj('get', this._pollIntervalsKeys[changedKey].capabilityId, this._pollIntervalsKeys[changedKey].commandClassId);
+				let pollInterval;
+				const pollMultiplication = capabilityGetObj.opts.pollMultiplication || 1;
+				pollInterval = newValue * pollMultiplication
+
 				this._setPollInterval(
 					this._pollIntervalsKeys[changedKey].capabilityId,
 					this._pollIntervalsKeys[changedKey].commandClassId,
-					newValue
+					pollInterval
 				);
 				continue;
 			}


### PR DESCRIPTION
`pollMultiplication` option is working correctly when initializing a Z-wave device... 
When changing the polling interval in settings, the pollMultiplication option is not taken into account.

See proposed change (implemented for polling interval as number) and tested ok on Remotec ZXT-120.

Note, this will require meshdriver updated in all apps already using the poll multiplication (e.g. Fibaro and Greenwave).