### PR TITLE
Add calculateZigBeeDimDuration method to util, fix zigbee/dim/genLeve…

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -37,6 +37,29 @@ function calculateZwaveDimDuration(duration) {
 	return 254;
 }
 
+/**
+ * Calculate a transtime value for ZigBee clusters, it takes two parameters, opts and settings. Opts is the opts object
+ * provided by a capbilityListener wich can hold a duration property (in miliseconds), settings is an object which can
+ * hold a 'transition_time' property (in seconds). If none are available, the default is 0. The valid value range is
+ * 0 - 6553.
+ * @param opts {object}
+ * @param opts.duration {number} - Duration property in miliseconds (preferred over 'transition_time')
+ * @param settings {object}
+ * @param settings.transition_time {number} - Transition time property in seconds
+ * @returns {number}
+ */
+function calculateZigBeeDimDuration(opts = {}, settings = {}) {
+	let transtime = 0;
+	if (opts.hasOwnProperty('duration')) {
+		transtime = opts.duration / 100;
+	} else if (typeof settings.transition_time === 'number') {
+		transtime = Math.round(settings.transition_time * 10);
+	}
+	// Cap the range between 0 and 6553
+	console.log('transtime', Math.max(Math.min(transtime, 6553), 0))
+	return Math.max(Math.min(transtime, 6553), 0);
+}
+
 
 /**
  * Utility class with several color and range conversion methods.
@@ -49,4 +72,5 @@ module.exports = {
 	convertRGBToHSV: color.convertRGBToHSV,
 	mapValueRange,
 	calculateZwaveDimDuration,
+	calculateZigBeeDimDuration,
 };

--- a/lib/zigbee/system/capabilities/dim/genLevelCtrl.js
+++ b/lib/zigbee/system/capabilities/dim/genLevelCtrl.js
@@ -1,25 +1,21 @@
 'use strict';
 
+const util = require('./../../../../util');
+
 const maxDim = 254;
 
 module.exports = {
-	set: 'moveToLevel',
-	setParser(value) {
+	set: 'moveToLevelWithOnOff',
+	setParser(value, opts = {}) {
 		if (value === 0) {
-			return this.triggerCapabilityListener('onoff', false)
-				.then(() => null)
-				.catch(err => new Error('failed_to_trigger_onoff'));
+			this.setCapabilityValue('onoff', false);
 		} else if (this.getCapabilityValue('onoff') === false && value > 0) {
-			return this.triggerCapabilityListener('onoff', true)
-				.then(() => ({
-					level: Math.round(value * maxDim),
-					transtime: this.getSetting('transition_time') ? Math.round(this.getSetting('transition_time') * 10) : 0,
-				}))
-				.catch(err => new Error('failed_to_trigger_onoff`', err));
+			this.setCapabilityValue('onoff', true);
 		}
+
 		return {
 			level: Math.round(value * maxDim),
-			transtime: this.getSetting('transition_time') ? Math.round(this.getSetting('transition_time') * 10) : 0,
+			transtime: util.calculateZigBeeDimDuration(opts, this.getSettings()),
 		};
 	},
 	get: 'currentLevel',


### PR DESCRIPTION
- Add `calculateZigBeeDimDuration` method to util
- Fix zigbee/dim/genLevelCtrl cluster set parser (it now handles on/off properly, and uses dim duration)
