### PR TITLE
Prevent type error

### DIFF
--- a/lib/MeshDevice.js
+++ b/lib/MeshDevice.js
@@ -88,11 +88,13 @@ class MeshDevice extends Homey.Device {
 		if (this.node) this.node.removeAllListeners();
 
 		// Clear all pollIntervals
-		Object.keys(this._pollIntervals).forEach(capabilityId => {
-			Object.values(this._pollIntervals[capabilityId]).forEach(interval => {
-				clearInterval(interval);
+		if (this._pollIntervals) { // Sometimes it is null/undefined for some reason
+			Object.keys(this._pollIntervals).forEach(capabilityId => {
+				Object.values(this._pollIntervals[capabilityId]).forEach(interval => {
+					clearInterval(interval);
+				});
 			});
-		});
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes some weird type errors where `this._pollIntervals` is null or undefined (https://sentry.io/athom-bv/comikeatradfri-rv/issues/738943815).