### PR TITLE
lower getParser versions

### DIFF
--- a/lib/zwave/system/capabilities/measure_power/METER.js
+++ b/lib/zwave/system/capabilities/measure_power/METER.js
@@ -32,7 +32,7 @@ module.exports = {
 	getOpts: {
 		getOnStart: true,
 	},
-	getParserV3: () => ({
+	getParserV2: () => ({
 		Properties1: {
 			Scale: 2,
 		},

--- a/lib/zwave/system/capabilities/meter_power/METER.js
+++ b/lib/zwave/system/capabilities/meter_power/METER.js
@@ -31,7 +31,7 @@ module.exports = {
 	getOpts: {
 		getOnStart: true,
 	},
-	getParserV3: () => ({
+	getParserV2: () => ({
 		Properties1: {
 			Scale: 0,
 		},

--- a/lib/zwave/system/capabilities/powerTotalApparent/METER.js
+++ b/lib/zwave/system/capabilities/powerTotalApparent/METER.js
@@ -31,7 +31,7 @@ module.exports = {
 	getOpts: {
 		getOnStart: true,
 	},
-	getParserV3: () => ({
+	getParserV2: () => ({
 		Properties1: {
 			Scale: 1,
 		},


### PR DESCRIPTION
Lowering a few METER command classes getParsers from v3 to v2 as it doesn't pick the first parser, but it is _from_ version number.
this will fix the 'invalid_type_expecting_object ["Properties1"]' error that were haunting a few (fibaro) drivers.