### PR TITLE
Fixes issue with edge values (0/1) for windowcoverings capabilities

### DIFF
--- a/lib/zwave/system/capabilities/dim/windowcoverings/SWITCH_MULTILEVEL.js
+++ b/lib/zwave/system/capabilities/dim/windowcoverings/SWITCH_MULTILEVEL.js
@@ -49,7 +49,7 @@ module.exports = {
 
 		if (report && report.hasOwnProperty('Value (Raw)')) {
 			if (report['Value (Raw)'][0] === 255) return invertDirection ? 0 : 1;
-			return invertDirection ? (100 - report['Value (Raw)'][0]) / 99 : report['Value (Raw)'][0] / 99;
+			return invertDirection ? (99 - report['Value (Raw)'][0]) / 99 : report['Value (Raw)'][0] / 99;
 		}
 		return null;
 	},
@@ -58,7 +58,7 @@ module.exports = {
 
 		if (report && report.hasOwnProperty('Current Value (Raw)')) {
 			if (report['Current Value (Raw)'][0] === 255) return invertDirection ? 0 : 1;
-			return invertDirection ? (100 - report['Current Value (Raw)'][0]) / 99 : report['Current Value (Raw)'][0] / 99;
+			return invertDirection ? (99 - report['Current Value (Raw)'][0]) / 99 : report['Current Value (Raw)'][0] / 99;
 		}
 		return null;
 	},

--- a/lib/zwave/system/capabilities/windowcoverings_tilt_set/SWITCH_MULTILEVEL.js
+++ b/lib/zwave/system/capabilities/windowcoverings_tilt_set/SWITCH_MULTILEVEL.js
@@ -49,7 +49,7 @@ module.exports = {
 
 		if (report && report.hasOwnProperty('Value (Raw)')) {
 			if (report['Value (Raw)'][0] === 255) return invertDirection ? 0 : 1;
-			return invertDirection ? (100 - report['Value (Raw)'][0]) / 99 : report['Value (Raw)'][0] / 99;
+			return invertDirection ? (99 - report['Value (Raw)'][0]) / 99 : report['Value (Raw)'][0] / 99;
 		}
 		return null;
 	},
@@ -58,7 +58,7 @@ module.exports = {
 
 		if (report && report.hasOwnProperty('Current Value (Raw)')) {
 			if (report['Current Value (Raw)'][0] === 255) return invertDirection ? 0 : 1;
-			return invertDirection ? (100 - report['Current Value (Raw)'][0]) / 99 : report['Current Value (Raw)'][0] / 99;
+			return invertDirection ? (99 - report['Current Value (Raw)'][0]) / 99 : report['Current Value (Raw)'][0] / 99;
 		}
 		return null;
 	},


### PR DESCRIPTION
This affects the following capabilities:
- dim (for device class windowcoverings)
- windowcoverings_tilt_set