### PR TITLE
Adds functionality that handles finding and setting energy properties

### DIFF
--- a/lib/zigbee/ZigBeeDevice.js
+++ b/lib/zigbee/ZigBeeDevice.js
@@ -91,7 +91,7 @@ class ZigBeeDevice extends MeshDevice {
 		this._debug('energy', energy);
 		if (!energy) {
 			const zigbeeProductId = this.getSetting('zb_product_id');
-			if (zigbeeProductId) return this.log('WARNING: _setEnergyObjectByProductId() -> could not find zigbeeProductId');
+			if (!zigbeeProductId) return this.log('WARNING: _setEnergyObjectByProductId() -> could not find zigbeeProductId');
 			energy = this.energyMap[zigbeeProductId] || null;
 			if (energy) return this.setEnergy(energy);
 			this.log('WARNING: _setEnergyObjectByProductId() -> no energy object found');

--- a/lib/zigbee/ZigBeeDevice.js
+++ b/lib/zigbee/ZigBeeDevice.js
@@ -55,6 +55,47 @@ class ZigBeeDevice extends MeshDevice {
 			this.onMeshInit && this.onMeshInit();
 			this._initNodeListeners();
 		});
+
+		// Check if energy map is available, if so set energy object
+		this._setEnergyObjectByProductId();
+	}
+
+	/**
+	 * Stub getter, can be overriden by subclass to provide energy properties per zb_product_id.
+	 * @example
+	 * class DimmableBulb extends ZigBeeDevice {
+	 *	    get energyMap() {
+	 *			return {
+	 *				'TRADFRI bulb E14 W op/ch 400lm': {
+	 *					approximation: {
+	 *						usageOff: 0,
+	 *						usageOn: 10
+	 *					}
+	 *				}
+	 *			}
+	 *		}
+	 *	}
+	 * @returns {{}}
+	 */
+	get energyMap() {
+		return {};
+	}
+
+	/**
+	 * Method that checks if a energyMap property is available on this device instance. If so it will check if an energy
+	 * object is available corresponding to the zb_product_id property of this device.
+	 * @private
+	 */
+	_setEnergyObjectByProductId() {
+		let energy = this.getEnergy();
+		this._debug('energy', energy);
+		if (!energy) {
+			const zigbeeProductId = this.getSetting('zb_product_id');
+			if (zigbeeProductId) return this.log('WARNING: _setEnergyObjectByProductId() -> could not find zigbeeProductId');
+			energy = this.energyMap[zigbeeProductId] || null;
+			if (energy) return this.setEnergy(energy);
+			this.log('WARNING: _setEnergyObjectByProductId() -> no energy object found');
+		}
 	}
 
 	/*


### PR DESCRIPTION
It expects a `get energyMap(){}` on the inheriting instance. This map should contain an object with productIds and their associated energy object. This allows for setting different energy objects on device instances of the same driver based on the zigbee productId.

@KyleAthom @WeeJeWel do you think this is a good idea? When working on energy for `com.ikea.tradfri` I had to figure out a way to set different energy objects based on ZigBee `productId` (since there are many different bulbs supported by a single driver). This allows for setting an `energyMap` object on the `ZigBeeDevice` instance. This `energyMap` object contains the energy objects per device (based on `productId`).