### PR TITLE
Fixes registering an extended system capability

### DIFF
--- a/lib/zigbee/ZigBeeDevice.js
+++ b/lib/zigbee/ZigBeeDevice.js
@@ -57,7 +57,9 @@ class ZigBeeDevice extends MeshDevice {
 		});
 
 		// Check if energy map is available, if so set energy object
-		this._setEnergyObjectByProductId();
+		if (typeof this.getEnergy === 'function') { // Check if energy is available, if not ignore
+			this._setEnergyObjectByProductId();
+		}
 	}
 
 	/**


### PR DESCRIPTION
When registering a capability (e.g. `onoff.output`) the system capability could not found due to the different capabilityId. This commit changes that before looking for system capabilities the capabilityId is spliced to determine the root capability.
