### PR TITLE
[ZwaveLightDevice] Fixes light_mode set error

### DIFF
--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -392,7 +392,10 @@ class ZwaveDevice extends MeshDevice {
 
 			const parsedPayload = capabilitySetObj.parser.call(this, value, opts);
 			if (parsedPayload instanceof Error) return Promise.reject(parsedPayload);
-
+			if (parsedPayload === null) {
+				this._debug(`WARNING: got parsedPayload null from capability (${capabilityId}) set parser, ignoring set.`);
+				return Promise.resolve();
+			}
 			try {
 				const commandClass = capabilitySetObj.node.CommandClass[`COMMAND_CLASS_${capabilitySetObj.commandClassId}`];
 				const command = commandClass[capabilitySetObj.commandId];

--- a/lib/zwave/ZwaveLightDevice.js
+++ b/lib/zwave/ZwaveLightDevice.js
@@ -186,6 +186,7 @@ class ZwaveLightDevice extends ZwaveDevice {
 						});
 					}
 				}, 50);
+				return null;
 			},
 		});
 


### PR DESCRIPTION
When a capability set parser returns `null` instead of an object the set is not executed and ignored.