### PR TITLE
[ZwaveDevice] Promisifies refreshCapabilityValue

### DIFF
--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -281,7 +281,7 @@ class ZwaveDevice extends MeshDevice {
 		if (capabilityGetObj.opts.getOnStart) {
 
 			// But not for battery devices
-			if (this.node.battery === false) this._getCapabilityValue(capabilityId, commandClassId);
+			if (this.node.battery === false) this._getCapabilityValue(capabilityId, commandClassId).catch(err => this.error('ERROR: _getCapabilityValue()', err));
 			else this.error('do not use getOnStart for battery devices, use getOnOnline instead');
 		}
 
@@ -292,14 +292,14 @@ class ZwaveDevice extends MeshDevice {
 			// Get immediately if node is still online (right after pairing for example)
 			if (this.node.battery === true && this.node.online === true) {
 				this.log(`Node online, getting commandClassId '${commandClassId}' for capabilityId '${capabilityId}'`);
-				this._getCapabilityValue(capabilityId, commandClassId);
+				this._getCapabilityValue(capabilityId, commandClassId).catch(err => this.error('ERROR: _getCapabilityValue()', err));
 			}
 
 			// Bind online listener for future events
 			this.node.on('online', online => {
 				if (online) {
 					this.log(`Node online, getting commandClassId '${commandClassId}' for capabilityId '${capabilityId}'`);
-					this._getCapabilityValue(capabilityId, commandClassId);
+					this._getCapabilityValue(capabilityId, commandClassId).catch(err => this.error('ERROR: _getCapabilityValue()', err));
 				}
 			});
 		}
@@ -343,41 +343,49 @@ class ZwaveDevice extends MeshDevice {
 
 		this._pollIntervals[capabilityId][commandClassId] = setInterval(() => {
 			this._debug(`Polling commandClassId '${commandClassId}' for capabilityId '${capabilityId}'`);
-			this._getCapabilityValue(capabilityId, commandClassId);
+			this._getCapabilityValue(capabilityId, commandClassId).catch(err => this.error('ERROR: _getCapabilityValue()', err));
 		}, pollInterval);
 
 	}
 
 
-	/**
-	 * @private
-	 */
-	_getCapabilityValue(capabilityId, commandClassId) {
+  /**
+   * @private
+   */
+  async _getCapabilityValue(capabilityId, commandClassId) {
+    return new Promise((resolve, reject) => {
+      const capabilityGetObj = this._getCapabilityObj('get', capabilityId, commandClassId);
+      if (capabilityGetObj instanceof Error) return reject(capabilityGetObj);
 
-		const capabilityGetObj = this._getCapabilityObj('get', capabilityId, commandClassId);
-		if (capabilityGetObj instanceof Error) return capabilityGetObj;
+      let parsedPayload = {};
 
-		let parsedPayload = {};
+      if (typeof capabilityGetObj.parser === 'function') {
+        parsedPayload = capabilityGetObj.parser.call(this);
+        if (parsedPayload instanceof Error) {
+          return reject(parsedPayload)
+        }
+      }
 
-		if (typeof capabilityGetObj.parser === 'function') {
-			parsedPayload = capabilityGetObj.parser.call(this);
-			if (parsedPayload instanceof Error) return this.error(parsedPayload);
-		}
+      try {
+        const commandClass = capabilityGetObj.node.CommandClass[`COMMAND_CLASS_${capabilityGetObj.commandClassId}`];
+        const command = commandClass[capabilityGetObj.commandId];
 
-		try {
-			const commandClass = capabilityGetObj.node.CommandClass[`COMMAND_CLASS_${capabilityGetObj.commandClassId}`];
-			const command = commandClass[capabilityGetObj.commandId];
+        return command.call(command, parsedPayload, (err, payload) => {
+          if (err) {
+            return reject(err)
+          }
 
-			return command.call(command, parsedPayload, (err, payload) => {
-				if (err) return this.error(err);
-
-				const result = this._onReport(capabilityId, commandClassId, payload);
-				if (result instanceof Error) return this.error(result);
-			});
-		} catch (err) {
-			return this.error(err);
-		}
-	}
+          const result = this._onReport(capabilityId, commandClassId, payload);
+          if (result instanceof Error) {
+            return reject(result)
+          }
+          return resolve(result);
+        });
+      } catch (err) {
+        return reject(err)
+      }
+    })
+  }
 
 	/**
 	 * @private
@@ -961,8 +969,9 @@ class ZwaveDevice extends MeshDevice {
 	 * the parameter getOpts.pollInterval at {@link ZwaveDevice#registerCapability}
 	 * @param {String} capabilityId, the string id of the Homey capability
 	 * @param {String} commandClassId, the Z-Wave command class used for this request
+   * @returns {Promise<unknown>}
 	 */
-	refreshCapabilityValue(capabilityId, commandClassId) {
+	async refreshCapabilityValue(capabilityId, commandClassId) {
 		return this._getCapabilityValue(capabilityId, commandClassId);
 	}
 

--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -353,38 +353,29 @@ class ZwaveDevice extends MeshDevice {
    * @private
    */
   async _getCapabilityValue(capabilityId, commandClassId) {
+    const capabilityGetObj = this._getCapabilityObj('get', capabilityId, commandClassId);
+    if (capabilityGetObj instanceof Error) throw capabilityGetObj;
+
+    let parsedPayload = {};
+
+    if (typeof capabilityGetObj.parser === 'function') {
+      parsedPayload = capabilityGetObj.parser.call(this);
+      if (parsedPayload instanceof Error) throw parsedPayload;
+    }
+
+    const commandClass = capabilityGetObj.node.CommandClass[`COMMAND_CLASS_${capabilityGetObj.commandClassId}`];
+    const command = commandClass[capabilityGetObj.commandId];
+
     return new Promise((resolve, reject) => {
-      const capabilityGetObj = this._getCapabilityObj('get', capabilityId, commandClassId);
-      if (capabilityGetObj instanceof Error) return reject(capabilityGetObj);
+      command.call(command, parsedPayload, (err, payload) => {
+        if (err) return reject(err);
 
-      let parsedPayload = {};
+        const result = this._onReport(capabilityId, commandClassId, payload);
+        if (result instanceof Error) return reject(result);
 
-      if (typeof capabilityGetObj.parser === 'function') {
-        parsedPayload = capabilityGetObj.parser.call(this);
-        if (parsedPayload instanceof Error) {
-          return reject(parsedPayload)
-        }
-      }
-
-      try {
-        const commandClass = capabilityGetObj.node.CommandClass[`COMMAND_CLASS_${capabilityGetObj.commandClassId}`];
-        const command = commandClass[capabilityGetObj.commandId];
-
-        return command.call(command, parsedPayload, (err, payload) => {
-          if (err) {
-            return reject(err)
-          }
-
-          const result = this._onReport(capabilityId, commandClassId, payload);
-          if (result instanceof Error) {
-            return reject(result)
-          }
-          return resolve(result);
-        });
-      } catch (err) {
-        return reject(err)
-      }
-    })
+        return resolve(result);
+      });
+    });
   }
 
 	/**


### PR DESCRIPTION
This is a breaking change, `refreshCapabilityValue` now returns a Promise which should be catched. Benefit of this change is that `refreshCapabilityValue` can now be awaited to get the actual value which was retrieved.