### PR TITLE
Extract _setCapabilityValue and expose via public executeCapabilitySetCommand

### DIFF
--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -388,9 +388,9 @@ class ZwaveDevice extends MeshDevice {
    * @returns {Promise<string|*>}
    */
   async _setCapabilityValue(capabilityId, commandClassId, value, opts = {}) {
-    if (typeof value === 'undefined') return this.error(`_setCapabilityValue() -> invalid value ${value} (capabilityId: ${capabilityId})`);
-    if (typeof capabilityId === 'undefined') return this.error(`_setCapabilityValue() -> invalid capabilityId ${capabilityId}`);
-    if (typeof commandClassId === 'undefined') return this.error(`_setCapabilityValue() -> invalid commandClassId ${commandClassId}`);
+    if (typeof value === 'undefined') throw new Error(`_setCapabilityValue -> invalid value ${value} (capabilityId: ${capabilityId})`);
+    if (typeof capabilityId === 'undefined') throw new Error(`_setCapabilityValue -> invalid capabilityId ${capabilityId}`);
+    if (typeof commandClassId === 'undefined') throw new Error(`_setCapabilityValue -> invalid commandClassId ${commandClassId}`);
 
     const capabilitySetObj = this._getCapabilityObj('set', capabilityId, commandClassId);
     if (capabilitySetObj instanceof Error) throw capabilitySetObj;

--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -378,30 +378,45 @@ class ZwaveDevice extends MeshDevice {
     });
   }
 
+  /**
+   * This method executes the capability set command for a given capability/commandClass combination. The capability
+   * and commandClass must be registered before this method is called.
+   * @param {string} capabilityId
+   * @param {string} commandClassId
+   * @param {Mixed} value - the capability value to set (e.g 0 - 1 for dim)
+   * @param {Object} opts - capability options object
+   * @returns {Promise<string|*>}
+   */
+  async _setCapabilityValue(capabilityId, commandClassId, value, opts = {}) {
+    if (typeof value === 'undefined') return this.error(`_setCapabilityValue() -> invalid value ${value} (capabilityId: ${capabilityId})`);
+    if (typeof capabilityId === 'undefined') return this.error(`_setCapabilityValue() -> invalid capabilityId ${capabilityId}`);
+    if (typeof commandClassId === 'undefined') return this.error(`_setCapabilityValue() -> invalid commandClassId ${commandClassId}`);
+
+    const capabilitySetObj = this._getCapabilityObj('set', capabilityId, commandClassId);
+    if (capabilitySetObj instanceof Error) throw capabilitySetObj;
+    if (typeof capabilitySetObj.parser !== 'function') throw new Error('missing_parser');
+
+    const parsedPayload = capabilitySetObj.parser.call(this, value, opts);
+    if (parsedPayload instanceof Error) throw parsedPayload;
+
+    const commandClass = capabilitySetObj.node.CommandClass[`COMMAND_CLASS_${capabilitySetObj.commandClassId}`];
+    const command = commandClass[capabilitySetObj.commandId];
+    const commandSetPromise = command.call(command, parsedPayload);
+    if (this.node.battery === true && this.node.online === false) return 'TRANSMIT_QUEUED';
+    return commandSetPromise;
+  }
+
 	/**
 	 * @private
-	 */
-	_registerCapabilitySet(capabilityId, commandClassId) {
+   */
+  _registerCapabilitySet(capabilityId, commandClassId) {
 
-		const capabilitySetObj = this._getCapabilityObj('set', capabilityId, commandClassId);
-		if (capabilitySetObj instanceof Error) return capabilitySetObj;
+    const capabilitySetObj = this._getCapabilityObj('set', capabilityId, commandClassId);
+    if (capabilitySetObj instanceof Error) return capabilitySetObj;
 
-		this.registerCapabilityListener(capabilityId, (value, opts) => (async () => {
-			if (typeof capabilitySetObj.parser !== 'function') return Promise.reject(new Error('missing_parser'));
-
-			const parsedPayload = capabilitySetObj.parser.call(this, value, opts);
-			if (parsedPayload instanceof Error) return Promise.reject(parsedPayload);
-
-			try {
-				const commandClass = capabilitySetObj.node.CommandClass[`COMMAND_CLASS_${capabilitySetObj.commandClassId}`];
-				const command = commandClass[capabilitySetObj.commandId];
-				const commandSetPromise = command.call(command, parsedPayload);
-				if (this.node.battery === true && this.node.online === false) return Promise.resolve('TRANSMIT_QUEUED');
-				return commandSetPromise;
-			} catch (err) {
-				return Promise.reject(err);
-			}
-		})().then(result => {
+    this.registerCapabilityListener(capabilityId, (value, opts) => (async () => {
+      return this._setCapabilityValue(capabilityId, commandClassId, value, opts)
+    })().then(result => {
 			if (typeof capabilitySetObj.opts.fn === 'function') {
 				process.nextTick(() => {
 					try {
@@ -787,7 +802,21 @@ class ZwaveDevice extends MeshDevice {
 		return this.node.CommandClass[`COMMAND_CLASS_${commandClassId}`];
 	}
 
-	/**
+  /**
+   * This method executes the capability set command for a given capability/commandClass combination. The capability
+   * and commandClass must be registered before this method is called.
+   * @param {string} capabilityId
+   * @param {string} commandClassId
+   * @param {Mixed} value - the capability value to set (e.g 0 - 1 for dim)
+   * @param {Object} opts - capability options object
+   * @returns {Promise<string|*>}
+   */
+  async executeCapabilitySetCommand(capabilityId, commandClassId, value, opts = {}) {
+    return this._setCapabilityValue(capabilityId, commandClassId, value, opts);
+  }
+
+
+  /**
 	 * Method that resets the accumulated power meter value on the node. It tries to find the root node of the device
 	 * and then looks for the COMMAND_CLASS_METER.
 	 * @param multiChannelNodeId - define the multi channel node id in case the COMMAND_CLASS_METER is on a multi channel node


### PR DESCRIPTION
This allows developers to directly call the set commands for a registered capability/commandClass combination.