### PR TITLE
[ZigBee] Move _setEnergyObjectByProductId() to __meshInit event

### DIFF
--- a/lib/zigbee/ZigBeeDevice.js
+++ b/lib/zigbee/ZigBeeDevice.js
@@ -55,13 +55,14 @@ class ZigBeeDevice extends MeshDevice {
 			if (typeof this.onMeshInit === 'function') {
 				this.onMeshInit();
 			}
+
+			// Check if energy map is available, if so set energy object
+      if (typeof this.getEnergy === 'function') { // Check if energy is available, if not ignore
+        this._setEnergyObjectByProductId();
+      }
+
 			this._initNodeListeners();
 		});
-
-		// Check if energy map is available, if so set energy object
-		if (typeof this.getEnergy === 'function') { // Check if energy is available, if not ignore
-			this._setEnergyObjectByProductId();
-		}
 	}
 
 	/**


### PR DESCRIPTION
This prevents _setEnergyObjectByProductId() from executing before the node has been inited.