### PR TITLE
When a capabilitySetParser returns null the set command will be ignored

### DIFF
--- a/lib/zigbee/ZigBeeDevice.js
+++ b/lib/zigbee/ZigBeeDevice.js
@@ -278,13 +278,16 @@ class ZigBeeDevice extends MeshDevice {
 	 */
 	async _registerCapabilityListenerHandler(capabilitySetObj, capabilityId, value, opts) {
 		this.log(`set ${capabilityId} -> ${value}`);
-		if (typeof capabilitySetObj.parser !== 'function') return Promise.reject(new Error('parser_is_not_a_function'));
+		if (typeof capabilitySetObj.parser !== 'function') throw new Error('parser_is_not_a_function');
 
 		let commandId = capabilitySetObj.commandId;
 		if (typeof capabilitySetObj.commandId === 'function') commandId = capabilitySetObj.commandId(value, opts);
 		const parsedPayload = await capabilitySetObj.parser.call(this, value, opts);
-		if (parsedPayload instanceof Error) return Promise.reject(parsedPayload);
-		if (parsedPayload === null) return Promise.resolve();
+		if (parsedPayload instanceof Error) throw parsedPayload;
+		if (parsedPayload === null) {
+      this._debug(`WARNING: got parsedPayload null from capability (${capabilityId}) set parser, ignoring set.`);
+      return 'IGNORED';
+    }
 
 		try {
 			const cluster = capabilitySetObj.node.endpoints[capabilitySetObj.endpoint].clusters[capabilitySetObj.clusterId];

--- a/lib/zwave/ZwaveDevice.js
+++ b/lib/zwave/ZwaveDevice.js
@@ -399,6 +399,10 @@ class ZwaveDevice extends MeshDevice {
 
     const parsedPayload = capabilitySetObj.parser.call(this, value, opts);
     if (parsedPayload instanceof Error) throw parsedPayload;
+    if (parsedPayload === null) {
+      this._debug(`WARNING: got parsedPayload null from capability (${capabilityId}) set parser, ignoring set.`);
+      return 'IGNORED';
+    }
 
     const commandClass = capabilitySetObj.node.CommandClass[`COMMAND_CLASS_${capabilitySetObj.commandClassId}`];
     const command = commandClass[capabilitySetObj.commandId];


### PR DESCRIPTION
This allows for sending different set commands from within specific system capability set parsers.