### PR TITLE
Fixes dim and onoff interaction for ZigBeeLightDevice

### DIFF
--- a/lib/zigbee/ZigBeeLightDevice.js
+++ b/lib/zigbee/ZigBeeLightDevice.js
@@ -4,15 +4,84 @@ const util = require('./../util');
 const ZigBeeDevice = require('homey-meshdriver').ZigBeeDevice;
 
 const maxHue = 254;
+const maxDim = 254;
 const maxSaturation = 254;
+
+const onoffCapabilityDefinition = {
+	capability: 'onoff',
+	cluster: 'genOnOff',
+	opts: {
+		get: 'onOff',
+		reportParser(value) {
+			return value === 1;
+		},
+		report: 'onOff',
+		getOpts: {
+			getOnStart: true,
+		},
+	}
+};
+
+const dimCapabilityDefinition = {
+	capability: 'dim',
+	cluster: 'genLevelCtrl',
+	opts: {
+		get: 'currentLevel',
+		reportParser(value) {
+			return value / maxDim;
+		},
+		report: 'currentLevel',
+		getOpts: {
+			getOnStart: true,
+		},
+	}
+}
 
 class ZigBeeLightDevice extends ZigBeeDevice {
 
 	async onMeshInit() {
 
-		// Register capabilities if present on device
-		if (this.hasCapability('onoff')) this.registerCapability('onoff', 'genOnOff');
-		if (this.hasCapability('dim')) this.registerCapability('dim', 'genLevelCtrl');
+		// Register multiple capabilities, they will be debounced when one of them is called
+		this.registerMultipleCapabilities([onoffCapabilityDefinition, dimCapabilityDefinition], (valueObj, optsObj) => {
+			if (valueObj.hasOwnProperty('onoff') && valueObj.hasOwnProperty('dim') && valueObj.onoff && valueObj.dim > 0) {
+				// Bulb is turned on and dimmed to a value, then just dim
+				return this.node.endpoints[this.getClusterEndpoint('genLevelCtrl')].clusters.genLevelCtrl.do('moveToLevelWithOnOff', {
+					level: Math.round(valueObj.dim * maxDim),
+					transtime: util.calculateZigBeeDimDuration(optsObj.dim, this.getSettings()),
+				});
+			} else if (valueObj.hasOwnProperty('onoff') && valueObj.hasOwnProperty('dim') && valueObj.onoff === false) {
+				// Bulb is turned off and dimmed to a value, then turn off
+				return this.node.endpoints[this.getClusterEndpoint('genOnOff')].clusters.genOnOff.do(valueObj.onoff ? 'on' : 'off', {})
+			} else if (valueObj.hasOwnProperty('onoff') && valueObj.hasOwnProperty('dim') && valueObj.onoff === true && valueObj.dim === 0) {
+				// Device is turned on and dimmed to zero, then just turn off
+				return this.node.endpoints[this.getClusterEndpoint('genOnOff')].clusters.genOnOff.do('off', {})
+			} else if (valueObj.hasOwnProperty('onoff')) {
+				// Device is only turned on/off, request new dim level afterwards
+				return this.node.endpoints[this.getClusterEndpoint('genOnOff')].clusters.genOnOff.do(valueObj.onoff ? 'on' : 'off', {})
+					.then(async () => {
+						if (valueObj.onoff === false) {
+							await this.setCapabilityValue('dim', 0);
+						} else if (valueObj.onoff) {
+							const dimLevel = await this.node.endpoints[this.getClusterEndpoint('genLevelCtrl')].clusters.genLevelCtrl.read('currentLevel');
+							return this.setCapabilityValue('dim', Math.max(0.01, dimLevel / maxDim)); // always set dim to 0.01 or higher since bulb is turned on
+						}
+					})
+			} else if (valueObj.hasOwnProperty('dim')) {
+
+				// Update onoff value
+				if (valueObj.dim === 0) {
+					this.setCapabilityValue('onoff', false).catch(err => this.error('failed to set onoff capability value', err));
+				} else if (this.getCapabilityValue('onoff') === false && valueObj.dim > 0) {
+					this.setCapabilityValue('onoff', true).catch(err => this.error('failed to set onoff capability value', err));
+				}
+
+				// Execute dim
+				return this.node.endpoints[this.getClusterEndpoint('genLevelCtrl')].clusters.genLevelCtrl.do('moveToLevelWithOnOff', {
+					level: Math.round(valueObj.dim * maxDim),
+					transtime: util.calculateZigBeeDimDuration(optsObj.dim, this.getSettings()),
+				});
+			}
+		})
 
 		// Register debounced capabilities
 		const groupedCapabilities = [];

--- a/lib/zigbee/ZigBeeLightDevice.js
+++ b/lib/zigbee/ZigBeeLightDevice.js
@@ -43,30 +43,33 @@ class ZigBeeLightDevice extends ZigBeeDevice {
 
 		// Register multiple capabilities, they will be debounced when one of them is called
 		this.registerMultipleCapabilities([onoffCapabilityDefinition, dimCapabilityDefinition], (valueObj, optsObj) => {
-			if (valueObj.hasOwnProperty('onoff') && valueObj.hasOwnProperty('dim') && valueObj.onoff && valueObj.dim > 0) {
-				// Bulb is turned on and dimmed to a value, then just dim
-				return this.node.endpoints[this.getClusterEndpoint('genLevelCtrl')].clusters.genLevelCtrl.do('moveToLevelWithOnOff', {
-					level: Math.round(valueObj.dim * maxDim),
-					transtime: util.calculateZigBeeDimDuration(optsObj.dim, this.getSettings()),
-				});
-			} else if (valueObj.hasOwnProperty('onoff') && valueObj.hasOwnProperty('dim') && valueObj.onoff === false) {
-				// Bulb is turned off and dimmed to a value, then turn off
-				return this.node.endpoints[this.getClusterEndpoint('genOnOff')].clusters.genOnOff.do(valueObj.onoff ? 'on' : 'off', {})
-			} else if (valueObj.hasOwnProperty('onoff') && valueObj.hasOwnProperty('dim') && valueObj.onoff === true && valueObj.dim === 0) {
-				// Device is turned on and dimmed to zero, then just turn off
-				return this.node.endpoints[this.getClusterEndpoint('genOnOff')].clusters.genOnOff.do('off', {})
-			} else if (valueObj.hasOwnProperty('onoff')) {
+			// Bulb is turned on/off
+			if (valueObj.hasOwnProperty('onoff')) {
+				if (valueObj.hasOwnProperty('dim') && valueObj.onoff && valueObj.dim > 0) {
+					// Bulb is turned on and dimmed to a value, then just dim
+					return this.node.endpoints[this.getClusterEndpoint('genLevelCtrl')].clusters.genLevelCtrl.do('moveToLevelWithOnOff', {
+						level: Math.round(valueObj.dim * maxDim),
+						transtime: util.calculateZigBeeDimDuration(optsObj.dim, this.getSettings()),
+					});
+				} else if (valueObj.hasOwnProperty('dim') && valueObj.onoff === false) {
+					// Bulb is turned off and dimmed to a value, then turn off
+					return this.node.endpoints[this.getClusterEndpoint('genOnOff')].clusters.genOnOff.do(valueObj.onoff ? 'on' : 'off', {})
+				} else if (valueObj.hasOwnProperty('dim') && valueObj.onoff === true && valueObj.dim === 0) {
+					// Device is turned on and dimmed to zero, then just turn off
+					return this.node.endpoints[this.getClusterEndpoint('genOnOff')].clusters.genOnOff.do('off', {})
+				}
+
 				// Device is only turned on/off, request new dim level afterwards
 				return this.node.endpoints[this.getClusterEndpoint('genOnOff')].clusters.genOnOff.do(valueObj.onoff ? 'on' : 'off', {})
 					.then(async () => {
 						if (valueObj.onoff === false) {
-							await this.setCapabilityValue('dim', 0);
+							await this.setCapabilityValue('dim', 0); // Set dim to zero when turned off
 						} else if (valueObj.onoff) {
 							const dimLevel = await this.node.endpoints[this.getClusterEndpoint('genLevelCtrl')].clusters.genLevelCtrl.read('currentLevel');
-							return this.setCapabilityValue('dim', Math.max(0.01, dimLevel / maxDim)); // always set dim to 0.01 or higher since bulb is turned on
+							return this.setCapabilityValue('dim', Math.max(0.01, dimLevel / maxDim)); // Always set dim to 0.01 or higher since bulb is turned on
 						}
 					})
-			} else if (valueObj.hasOwnProperty('dim')) {
+			} else if (valueObj.hasOwnProperty('dim')) { // Bulb is only dimmed
 
 				// Update onoff value
 				if (valueObj.dim === 0) {


### PR DESCRIPTION
The `dim` and `onoff` capabilities used to be completely separate. But this was not inline with other implementations on Homey (e.g. for Z-Wave light devices). When a light is turned off, the dim level should reflect that the device is off (hence being zero). When the light is turned on again the dim level should be reset to the value before it was turned off.

This PR bundles the `onoff` and `dim` capabilities and makes sure this behaviour is corrected. Main change, after a light is turned on the dim value is requested from the device and updated on Homey. Further, the `dim` capability follows the `onoff` capability and vice versa.