### PR TITLE
Fixes SWITCH_MULTILEVEL_SET V4

### DIFF
--- a/lib/zwave/system/capabilities/dim/SWITCH_MULTILEVEL.js
+++ b/lib/zwave/system/capabilities/dim/SWITCH_MULTILEVEL.js
@@ -30,7 +30,7 @@ module.exports = {
 		if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', value > 0);
 		return {
 			Value: Math.round(value * 99),
-			'Dimming Duration': duration,
+			'Dimming Duration': Buffer.from([duration]), // Buffer.from() is a fix for difference between V3/V4 dimming duration XML specification
 		};
 	},
 	report: 'SWITCH_MULTILEVEL_REPORT',


### PR DESCRIPTION
Buffer.from() is a fix for difference between V3/V4 dimming duration XML specification.