### PR TITLE
Fixes all SWITCH_MULTILEVEL_SET V4 parsers

### DIFF
--- a/lib/zwave/system/capabilities/dim/SWITCH_MULTILEVEL.js
+++ b/lib/zwave/system/capabilities/dim/SWITCH_MULTILEVEL.js
@@ -26,8 +26,9 @@ module.exports = {
 		};
 	},
 	setParserV4(value, options) {
-		const duration = (options.hasOwnProperty('duration') ? util.calculateZwaveDimDuration(options.duration) : FACTORY_DEFAULT_DIMMING_DURATION_V4);
-		if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', value > 0);
+    // Buffer.from() is a fix for difference between V3/V4 dimming duration XML specification
+    const duration = (options.hasOwnProperty('duration') ? Buffer.from([util.calculateZwaveDimDuration(options.duration)]) : FACTORY_DEFAULT_DIMMING_DURATION_V4);
+    if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', value > 0);
 		return {
 			Value: Math.round(value * 99),
 			'Dimming Duration': duration,

--- a/lib/zwave/system/capabilities/dim/SWITCH_MULTILEVEL.js
+++ b/lib/zwave/system/capabilities/dim/SWITCH_MULTILEVEL.js
@@ -31,7 +31,7 @@ module.exports = {
     if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', value > 0);
 		return {
 			Value: Math.round(value * 99),
-			'Dimming Duration': Buffer.from([duration]), // Buffer.from() is a fix for difference between V3/V4 dimming duration XML specification
+			'Dimming Duration': duration,
 		};
 	},
 	report: 'SWITCH_MULTILEVEL_REPORT',

--- a/lib/zwave/system/capabilities/dim/windowcoverings/SWITCH_MULTILEVEL.js
+++ b/lib/zwave/system/capabilities/dim/windowcoverings/SWITCH_MULTILEVEL.js
@@ -32,8 +32,9 @@ module.exports = {
 		};
 	},
 	setParserV4(value, options) {
-		const duration = (options.hasOwnProperty('duration') ? util.calculateZwaveDimDuration(options.duration) : FACTORY_DEFAULT_DIMMING_DURATION_V4);
-		if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', value > 0);
+    // Buffer.from() is a fix for difference between V3/V4 dimming duration XML specification
+    const duration = (options.hasOwnProperty('duration') ? Buffer.from([util.calculateZwaveDimDuration(options.duration)]) : FACTORY_DEFAULT_DIMMING_DURATION_V4);
+    if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', value > 0);
 
 		const invertDirection = !!this.getSetting(INVERT_WINDOW_COVERINGS_DIRECTION);
 		if (invertDirection) value = 1 - value;

--- a/lib/zwave/system/capabilities/windowcoverings_set/SWITCH_MULTILEVEL.js
+++ b/lib/zwave/system/capabilities/windowcoverings_set/SWITCH_MULTILEVEL.js
@@ -30,7 +30,8 @@ module.exports = {
     };
   },
   setParserV4(value, options) {
-    const duration = (options.hasOwnProperty('duration') ? util.calculateZwaveDimDuration(options.duration) : FACTORY_DEFAULT_DIMMING_DURATION_V4);
+    // Buffer.from() is a fix for difference between V3/V4 dimming duration XML specification
+    const duration = (options.hasOwnProperty('duration') ? Buffer.from([util.calculateZwaveDimDuration(options.duration)]) : FACTORY_DEFAULT_DIMMING_DURATION_V4);
     if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', value > 0);
 
     const invertDirection = !!this.getSetting(INVERT_WINDOW_COVERINGS_DIRECTION);

--- a/lib/zwave/system/capabilities/windowcoverings_tilt_set/SWITCH_MULTILEVEL.js
+++ b/lib/zwave/system/capabilities/windowcoverings_tilt_set/SWITCH_MULTILEVEL.js
@@ -32,7 +32,8 @@ module.exports = {
 		};
 	},
 	setParserV4(value, options) {
-		const duration = (options.hasOwnProperty('duration') ? util.calculateZwaveDimDuration(options.duration) : FACTORY_DEFAULT_DIMMING_DURATION_V4);
+    // Buffer.from() is a fix for difference between V3/V4 dimming duration XML specification
+    const duration = (options.hasOwnProperty('duration') ? Buffer.from([util.calculateZwaveDimDuration(options.duration)]) : FACTORY_DEFAULT_DIMMING_DURATION_V4);
 		if (this.hasCapability('onoff')) this.setCapabilityValue('onoff', value > 0);
 
 		const invertDirection = !!this.getSetting(INVERT_WINDOW_COVERINGS_TILT_DIRECTION);


### PR DESCRIPTION
Buffer.from() is a fix for difference between V3/V4 dimming duration XML specification