### PR TITLE
fix: add missing parsed attribute

### DIFF
--- a/lib/zwave/system/commandclasses/NOTIFICATION/index.js
+++ b/lib/zwave/system/commandclasses/NOTIFICATION/index.js
@@ -22,6 +22,8 @@ module.exports = payload => {
 			name = events[eventNotificationType][eventCode].pull;
 		}
 
+		payload['Event (Parsed)'] = name;
+		// Not sure why this exists, we use "Event (Parsed)" and they are the same
 		payload['Event (Parsed 2)'] = name;
 	}
 


### PR DESCRIPTION
Instead of overwriting the `(Parsed)` we are adding a `(Parsed 2)` for COMMAND_CLASS_NOTIFICATION.
`(Parsed)` and `(Parsed 2)` are both created using the same logic so they should be the same, since we don't use `(Parsed 2)` anywhere I'm adding `(Parsed)` for clarity.